### PR TITLE
Add development environment setup (AGENTS.md)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,32 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is a collection of standalone static HTML pages (no build system, no package manager, no backend). Each `.html` file is a self-contained page with inline CSS and JS.
+
+### Serving the pages
+
+Run from `/workspace`:
+
+```
+python3 -m http.server 8080
+```
+
+All pages are then available at `http://localhost:8080/<filename>.html`.
+
+### Pages
+
+| File | Description |
+|---|---|
+| `index.html` | Retro vinyl music player (uses external MP3s from soundhelix.com) |
+| `music_player.html` | "Eternal Memory" music player variant |
+| `ar_shanghai.html` | Shanghai Phantom AR collectible card platform |
+| `taiwei_machinery.html` | Taiwei Machinery corporate website |
+| `README.html` | Animated envelope/letter UI |
+| `shanghai-phantom/index.html` | Extended Shanghai Phantom page (uses Font Awesome CDN) |
+
+### Notes
+
+- No lint, test, or build commands exist — there are no dependencies to install.
+- External resources (images from Unsplash/picsum, audio from SoundHelix, Font Awesome CDN) require internet access.
+- All content is in Chinese (Simplified).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with Cursor Cloud specific development environment instructions for this static HTML codebase.

## What was done

- Explored the codebase structure: 6 standalone static HTML pages (no build system, no backend, no package manager)
- Configured a minimal update script (no-op since there are no dependencies)
- Created `AGENTS.md` documenting how to serve and develop the pages
- Verified all 6 HTML pages serve correctly via `python3 -m http.server`
- Tested interactive features across all pages (music players, AR platform, corporate site, envelope UI)

## Demo

[demo_all_pages_walkthrough.mp4](https://cursor.com/agents/bc-c1116810-4366-414b-8471-f9e0a47128a8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdemo_all_pages_walkthrough.mp4)

Pages working in browser — vinyl music player, Shanghai Phantom, Taiwei Machinery, and envelope letter UI all rendered and interactive.

[Retro vinyl music player](https://cursor.com/agents/bc-c1116810-4366-414b-8471-f9e0a47128a8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmusic_player_vinyl.webp)
[Shanghai Phantom AR platform](https://cursor.com/agents/bc-c1116810-4366-414b-8471-f9e0a47128a8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fshanghai_phantom.webp)
[Taiwei Machinery corporate site](https://cursor.com/agents/bc-c1116810-4366-414b-8471-f9e0a47128a8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftaiwei_machinery.webp)
[Envelope letter opened](https://cursor.com/agents/bc-c1116810-4366-414b-8471-f9e0a47128a8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fenvelope_opened.webp)

## How to serve

```bash
cd /workspace
python3 -m http.server 8080
```

Then open `http://localhost:8080/<filename>.html` in a browser.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c1116810-4366-414b-8471-f9e0a47128a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c1116810-4366-414b-8471-f9e0a47128a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

