### PR TITLE
Industrial Code Hygiene & Safety Hardening

### DIFF
--- a/vcs_press/.github/workflows/ci.yml
+++ b/vcs_press/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: VCS Press CI
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: vcs_press
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: Install dependencies
+        run: python -m pip install -r requirements.txt
+      - name: Unicode safety
+        run: python scripts/check_unicode_safety.py
+      - name: Ruff
+        run: ruff check .
+      - name: Black
+        run: black --check .
+      - name: Isort
+        run: isort --check-only .
+      - name: Tests
+        run: python -m pytest -q

--- a/vcs_press/.pre-commit-config.yaml
+++ b/vcs_press/.pre-commit-config.yaml
@@ -1,0 +1,28 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.8.6
+    hooks:
+      - id: ruff
+        args: ["--fix"]
+  - repo: https://github.com/psf/black
+    rev: 24.10.0
+    hooks:
+      - id: black
+  - repo: https://github.com/pycqa/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
+  - repo: local
+    hooks:
+      - id: unicode-safety
+        name: unicode-safety
+        entry: python scripts/check_unicode_safety.py
+        language: system
+        types_or: [python, yaml, markdown, text]

--- a/vcs_press/README.md
+++ b/vcs_press/README.md
@@ -43,10 +43,26 @@ Install the real LightGlue backend only on machines that need it:
 
 Open `http://127.0.0.1:8000/` for the minimal HMI.
 
+## Industrial safety principles
+
+The vision system is advisory only. It may output `allow_punch`, `x_offset_mm`, `y_offset_mm`, `theta_offset_deg`, `feed_offset_mm`, confidence, and alarm information. It must never expose or call an API that directly commands the punch head to descend. Final punch motion belongs to the PLC or Safety PLC after all machine safety conditions are satisfied.
+
+Fail-closed rules:
+
+- Startup default is `allow_punch=false`.
+- Any exception, timeout, lost communication, camera fault, light fault, model failure, low confidence, high residual, excessive compensation, excessive deformation, missing calibration, missing job, safety door fault, light curtain fault, low air pressure, PLC fault, or emergency stop forces `allow_punch=false`.
+- `ServoService.send_to_plc()` writes `allow_punch=false` before sending a new payload, so a previous true value cannot survive a rejected cycle.
+- `ALARM` recovery requires explicit `POST /system/reset_alarm`.
+- `EMERGENCY_STOP` recovery requires `POST /system/ack_emergency_stop` with PLC and operator acknowledgement flags.
+
+Alarm events include `alarm_code`, `alarm_message`, `severity`, `timestamp`, and `recommended_action`. Severity values are `INFO`, `WARNING`, `CRITICAL`, and `EMERGENCY`.
+
 ## API quick flow
 
 - `GET /health`
 - `POST /system/init`
+- `POST /system/reset_alarm`
+- `POST /system/ack_emergency_stop`
 - `POST /calibration/start`
 - `POST /job/load`
 - `POST /vision/register`
@@ -68,6 +84,28 @@ Use LightGlue through the API after installing the optional backend:
 
 The simulated camera generates four reference holes for self-calibration and a shifted material image for registration. MockDeepMatcher emits dense correspondences; registration computes the global offset; TPS estimates residual local deformation; ServoService checks safety thresholds and writes only recommendations to SimulatedPLC.
 
+## CI and pre-commit
+
+Install development hooks:
+
+`pip install -r requirements.txt`
+
+`pre-commit install`
+
+Run the same checks as CI:
+
+`python scripts/check_unicode_safety.py`
+
+`ruff check .`
+
+`black --check .`
+
+`isort --check-only .`
+
+`python -m pytest -q`
+
+The Unicode safety check rejects hidden bidirectional controls and zero-width characters in `.py`, `.yaml`, `.md`, and `.txt` files. This prevents misleading source display, unsafe copy/paste artifacts, and Trojan-source style code review bypasses.
+
 ## Real camera integration
 
 Implement a subclass of `CameraBase` for Basler, Hikvision, Daheng, or MindVision SDKs. Map exposure, gain, trigger mode, hardware trigger arm, timestamp, frame timeout, and exception handling into the common `Frame` result. Keep `SimulatedCamera` enabled for offline commissioning and CI tests.
@@ -83,6 +121,14 @@ Install and validate `snap7`, then replace `SiemensS7PLCStub` methods with DB bl
 ## Safety notes
 
 Punching is forbidden when emergency stop, safety door, PLC fault, low air pressure, camera or light fault, missing calibration, CAD not loaded, low confidence, low inlier ratio, high residual, excessive compensation, excessive deformation, or repeated NG occurs. Final punch motion must stay under PLC safety control.
+
+## Simulated safety test flow
+
+Use pytest to validate fail-closed behavior without hardware:
+
+- `tests/test_industrial_safety.py` covers emergency stop, safety door, light curtain, air pressure, PLC disconnect, heartbeat loss, camera/light faults, missing calibration/job, low matching quality, compensation limits, deformation limits, and consecutive NG.
+- `tests/test_timeout_safety.py` covers camera acquisition, vision cycle, PLC ACK, light ready, and post-inspection timeouts.
+- `tests/test_state_machine_safety.py` verifies `ALARM` needs explicit reset and `EMERGENCY_STOP` needs PLC plus operator acknowledgement.
 
 ## Tests
 

--- a/vcs_press/app/api/routes.py
+++ b/vcs_press/app/api/routes.py
@@ -6,6 +6,7 @@ from fastapi import FastAPI, WebSocket
 from fastapi.responses import HTMLResponse
 from pydantic import BaseModel
 
+from app.api.websocket import StatusBroadcaster
 from app.cad.dxf_parser import DXFParser
 from app.cad.job_model import Job, demo_job
 from app.calibration.calibration_service import CalibrationService
@@ -17,14 +18,13 @@ from app.inspection.post_inspection import PostInspectionService
 from app.online_learning.online_compensator import OnlineCompensator
 from app.plc.simulated_plc import SimulatedPLC
 from app.registration.registration_service import RegistrationService
+from app.safety.alarm_codes import make_alarm
 from app.servo.servo_service import ServoService
 from app.state_machine.controller import StateMachineController
 from app.state_machine.states import MachineState
-from app.storage.repository import InMemoryRepository
 from app.storage.report_writer import ReportWriter
+from app.storage.repository import InMemoryRepository
 from app.vision_matching.matching_service import MatchingService
-
-from app.api.websocket import StatusBroadcaster
 
 
 class JobLoadRequest(BaseModel):
@@ -34,6 +34,11 @@ class JobLoadRequest(BaseModel):
 
 class VisionRegisterRequest(BaseModel):
     matcher: str | None = None
+
+
+class EmergencyAckRequest(BaseModel):
+    plc_confirmed: bool = False
+    operator_confirmed: bool = False
 
 
 class AppContext:
@@ -89,7 +94,10 @@ def create_app() -> FastAPI:
         <button onclick="fetch('/inspection/run',{method:'POST'}).then(load)">Post Inspection</button>
         <pre id="status"></pre>
         <script>
-        async function load(){document.getElementById('status').textContent=JSON.stringify(await (await fetch('/system/status')).json(), null, 2)}
+        async function load(){
+          const response = await fetch('/system/status');
+          document.getElementById('status').textContent = JSON.stringify(await response.json(), null, 2);
+        }
         load(); setInterval(load, 2000)
         </script></body></html>
         """
@@ -106,6 +114,18 @@ def create_app() -> FastAPI:
     def system_init() -> dict:
         if ctx.state_machine.state == MachineState.IDLE:
             ctx.state_machine.transition(MachineState.INIT, "system init requested")
+        return ctx.status()
+
+    @app.post("/system/reset_alarm")
+    def reset_alarm() -> dict:
+        ctx.state_machine.reset_alarm()
+        ctx.plc.write_allow_punch(False)
+        return ctx.status()
+
+    @app.post("/system/ack_emergency_stop")
+    def ack_emergency_stop(request: EmergencyAckRequest) -> dict:
+        ctx.state_machine.acknowledge_emergency_stop(request.plc_confirmed, request.operator_confirmed)
+        ctx.plc.write_allow_punch(False)
         return ctx.status()
 
     @app.post("/calibration/start")
@@ -158,8 +178,15 @@ def create_app() -> FastAPI:
     def servo_compute() -> dict:
         if ctx.registration.latest_result is None or ctx.deformation.latest_field is None:
             vision_register()
-        result = ctx.servo.compute(ctx.registration.latest_result, ctx.deformation.latest_field, calibrated=ctx.calibrated, cad_loaded=ctx.job is not None)
-        _goto(ctx, MachineState.COMPENSATION_READY if result["allow_punch"] else MachineState.ALARM, result.get("alarm_message", "compensation computed"))
+        result = ctx.servo.compute(
+            ctx.registration.latest_result, ctx.deformation.latest_field, calibrated=ctx.calibrated, cad_loaded=ctx.job is not None
+        )
+        if result["allow_punch"]:
+            _goto(ctx, MachineState.COMPENSATION_READY, "compensation ready")
+        else:
+            ctx.state_machine.enter_alarm(
+                make_alarm(result.get("alarm_code", "VISION_REJECT"), result.get("alarm_message", "vision rejected punch"))
+            )
         return result
 
     @app.post("/servo/send_to_plc")

--- a/vcs_press/app/cad/dxf_parser.py
+++ b/vcs_press/app/cad/dxf_parser.py
@@ -37,7 +37,7 @@ class DXFParser:
         all_points = [p for contour in contours for p in contour] + holes + keypoints
         bbox = None
         if all_points:
-            xs, ys = zip(*all_points)
+            xs, ys = zip(*all_points, strict=False)
             bbox = (min(xs), min(ys), max(xs), max(ys))
         regions = [CutRegion(f"part_{i+1:03d}", _center(contour), contour) for i, contour in enumerate(contours)]
         return Job(
@@ -52,5 +52,5 @@ class DXFParser:
 
 
 def _center(points: list[tuple[float, float]]) -> tuple[float, float]:
-    xs, ys = zip(*points)
+    xs, ys = zip(*points, strict=False)
     return (float(sum(xs) / len(xs)), float(sum(ys) / len(ys)))

--- a/vcs_press/app/calibration/solver.py
+++ b/vcs_press/app/calibration/solver.py
@@ -49,10 +49,7 @@ class CalibrationSolver:
             raise ValueError(f"unsupported calibration mode: {mode}")
         if matrix is None:
             raise ValueError("calibration transform solve failed")
-        if mode != "homography":
-            matrix3 = np.vstack([matrix, [0.0, 0.0, 1.0]])
-        else:
-            matrix3 = matrix
+        matrix3 = np.vstack([matrix, [0.0, 0.0, 1.0]]) if mode != "homography" else matrix
         projected = apply_transform(src, matrix3)
         errors = np.linalg.norm(projected - dst, axis=1)
         inverse = np.linalg.inv(matrix3)

--- a/vcs_press/app/plc/base.py
+++ b/vcs_press/app/plc/base.py
@@ -7,7 +7,9 @@ from dataclasses import dataclass, field
 @dataclass
 class SafetySignals:
     emergency_stop: bool = False
+    safety_door_closed: bool = True
     safety_door_open: bool = False
+    light_curtain_ok: bool = True
     air_pressure_ok: bool = True
     punch_top_dead_center: bool = True
     punch_bottom_dead_center: bool = False
@@ -24,6 +26,7 @@ class MachinePosition:
 @dataclass
 class PLCStatus:
     connected: bool = True
+    plc_alive: bool = True
     state_code: int = 0
     position: MachinePosition = field(default_factory=MachinePosition)
     safety: SafetySignals = field(default_factory=SafetySignals)

--- a/vcs_press/app/plc/simulated_plc.py
+++ b/vcs_press/app/plc/simulated_plc.py
@@ -18,7 +18,9 @@ class SimulatedPLC(PLCBase):
         return self.status
 
     def write_compensation(self, payload: dict) -> None:
-        self.status.last_compensation = payload
+        self.status.last_compensation = dict(payload)
+        self.status.last_compensation["allow_punch"] = bool(payload.get("allow_punch", False))
+        self.allow_punch = self.status.last_compensation["allow_punch"]
 
     def write_allow_punch(self, allow: bool) -> None:
         self.allow_punch = bool(allow)

--- a/vcs_press/app/safety/__init__.py
+++ b/vcs_press/app/safety/__init__.py
@@ -1,4 +1,4 @@
-from app.safety.alarm_codes import AlarmCodes
+from app.safety.alarm_codes import AlarmCodes, AlarmDefinition, AlarmEvent, AlarmSeverity, make_alarm
 from app.safety.safety_checker import SafetyChecker, SafetyDecision
 
-__all__ = ["AlarmCodes", "SafetyChecker", "SafetyDecision"]
+__all__ = ["AlarmCodes", "AlarmDefinition", "AlarmEvent", "AlarmSeverity", "SafetyChecker", "SafetyDecision", "make_alarm"]

--- a/vcs_press/app/safety/alarm_codes.py
+++ b/vcs_press/app/safety/alarm_codes.py
@@ -1,9 +1,53 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+from app.utils.time_utils import utc_now_iso
+
+
+class AlarmSeverity(str, Enum):
+    INFO = "INFO"
+    WARNING = "WARNING"
+    CRITICAL = "CRITICAL"
+    EMERGENCY = "EMERGENCY"
+
+
+@dataclass(frozen=True)
+class AlarmDefinition:
+    alarm_code: str
+    alarm_message: str
+    severity: AlarmSeverity
+    recommended_action: str
+
+
+@dataclass
+class AlarmEvent:
+    alarm_code: str
+    alarm_message: str
+    severity: AlarmSeverity
+    recommended_action: str
+    timestamp: str
+
+    def to_dict(self) -> dict:
+        return {
+            "alarm_code": self.alarm_code,
+            "alarm_message": self.alarm_message,
+            "severity": self.severity.value,
+            "timestamp": self.timestamp,
+            "recommended_action": self.recommended_action,
+        }
+
+
 class AlarmCodes:
     OK = "OK"
     EMERGENCY_STOP = "E_STOP"
     SAFETY_DOOR = "SAFETY_DOOR_OPEN"
+    LIGHT_CURTAIN = "LIGHT_CURTAIN_BLOCKED"
     AIR_PRESSURE = "AIR_PRESSURE_LOW"
     PLC_FAULT = "PLC_FAULT"
+    PLC_DISCONNECTED = "PLC_DISCONNECTED"
+    PLC_ALIVE_LOST = "PLC_ALIVE_LOST"
     CAMERA_OFFLINE = "CAMERA_OFFLINE"
     LIGHT_FAULT = "LIGHT_FAULT"
     CALIBRATION_REQUIRED = "CALIBRATION_REQUIRED"
@@ -15,3 +59,186 @@ class AlarmCodes:
     COMPENSATION_LIMIT = "COMPENSATION_LIMIT"
     DEFORMATION_LIMIT = "DEFORMATION_LIMIT"
     CONSECUTIVE_NG = "CONSECUTIVE_NG"
+    VISION_CYCLE_TIMEOUT = "VISION_CYCLE_TIMEOUT"
+    PLC_ACK_TIMEOUT = "PLC_ACK_TIMEOUT"
+    CAMERA_ACQUIRE_TIMEOUT = "CAMERA_ACQUIRE_TIMEOUT"
+    LIGHT_READY_TIMEOUT = "LIGHT_READY_TIMEOUT"
+    POST_INSPECTION_TIMEOUT = "POST_INSPECTION_TIMEOUT"
+    MODEL_MATCH_FAILED = "MODEL_MATCH_FAILED"
+    VISION_EXCEPTION = "VISION_EXCEPTION"
+    MANUAL_RESET_REQUIRED = "MANUAL_RESET_REQUIRED"
+
+
+ALARM_DEFINITIONS: dict[str, AlarmDefinition] = {
+    AlarmCodes.OK: AlarmDefinition(AlarmCodes.OK, "system ok", AlarmSeverity.INFO, "No action required."),
+    AlarmCodes.EMERGENCY_STOP: AlarmDefinition(
+        AlarmCodes.EMERGENCY_STOP,
+        "emergency stop is active",
+        AlarmSeverity.EMERGENCY,
+        "Keep punch disabled. Inspect and reset emergency stop through PLC and operator procedure.",
+    ),
+    AlarmCodes.SAFETY_DOOR: AlarmDefinition(
+        AlarmCodes.SAFETY_DOOR,
+        "safety door is not closed",
+        AlarmSeverity.CRITICAL,
+        "Close safety door and verify safety relay before resetting alarm.",
+    ),
+    AlarmCodes.LIGHT_CURTAIN: AlarmDefinition(
+        AlarmCodes.LIGHT_CURTAIN,
+        "light curtain is blocked or unhealthy",
+        AlarmSeverity.CRITICAL,
+        "Clear light curtain and verify safety input before allowing production.",
+    ),
+    AlarmCodes.AIR_PRESSURE: AlarmDefinition(
+        AlarmCodes.AIR_PRESSURE,
+        "air pressure is not ok",
+        AlarmSeverity.CRITICAL,
+        "Restore pneumatic pressure and verify PLC safety input.",
+    ),
+    AlarmCodes.PLC_FAULT: AlarmDefinition(
+        AlarmCodes.PLC_FAULT,
+        "PLC safety status is abnormal",
+        AlarmSeverity.CRITICAL,
+        "Check PLC diagnostics and safety inputs.",
+    ),
+    AlarmCodes.PLC_DISCONNECTED: AlarmDefinition(
+        AlarmCodes.PLC_DISCONNECTED,
+        "PLC communication is disconnected",
+        AlarmSeverity.CRITICAL,
+        "Restore PLC communication. Keep allow_punch false.",
+    ),
+    AlarmCodes.PLC_ALIVE_LOST: AlarmDefinition(
+        AlarmCodes.PLC_ALIVE_LOST,
+        "PLC heartbeat is lost",
+        AlarmSeverity.CRITICAL,
+        "Check PLC heartbeat and network before reset.",
+    ),
+    AlarmCodes.CAMERA_OFFLINE: AlarmDefinition(
+        AlarmCodes.CAMERA_OFFLINE,
+        "camera is offline",
+        AlarmSeverity.CRITICAL,
+        "Reconnect camera and verify acquisition before reset.",
+    ),
+    AlarmCodes.LIGHT_FAULT: AlarmDefinition(
+        AlarmCodes.LIGHT_FAULT,
+        "light controller is not ready",
+        AlarmSeverity.CRITICAL,
+        "Check light controller power, trigger, and brightness configuration.",
+    ),
+    AlarmCodes.CALIBRATION_REQUIRED: AlarmDefinition(
+        AlarmCodes.CALIBRATION_REQUIRED,
+        "self calibration is not complete or not ok",
+        AlarmSeverity.CRITICAL,
+        "Run self calibration and verify reprojection error.",
+    ),
+    AlarmCodes.CALIBRATION_ERROR: AlarmDefinition(
+        AlarmCodes.CALIBRATION_ERROR,
+        "calibration error exceeds threshold",
+        AlarmSeverity.CRITICAL,
+        "Inspect reference holes, camera focus, lighting, and machine point order.",
+    ),
+    AlarmCodes.CAD_NOT_LOADED: AlarmDefinition(
+        AlarmCodes.CAD_NOT_LOADED,
+        "CAD/job is not loaded",
+        AlarmSeverity.CRITICAL,
+        "Load a valid job before requesting compensation.",
+    ),
+    AlarmCodes.MATCH_LOW_CONFIDENCE: AlarmDefinition(
+        AlarmCodes.MATCH_LOW_CONFIDENCE,
+        "matching confidence is too low",
+        AlarmSeverity.WARNING,
+        "Check material placement, lighting, template, and fallback matcher results.",
+    ),
+    AlarmCodes.MATCH_LOW_INLIER: AlarmDefinition(
+        AlarmCodes.MATCH_LOW_INLIER,
+        "matching inlier ratio is too low",
+        AlarmSeverity.WARNING,
+        "Inspect feature matches and material texture.",
+    ),
+    AlarmCodes.RESIDUAL_TOO_HIGH: AlarmDefinition(
+        AlarmCodes.RESIDUAL_TOO_HIGH,
+        "registration residual is too high",
+        AlarmSeverity.WARNING,
+        "Reacquire image, check material deformation, and verify calibration.",
+    ),
+    AlarmCodes.COMPENSATION_LIMIT: AlarmDefinition(
+        AlarmCodes.COMPENSATION_LIMIT,
+        "compensation exceeds machine limit",
+        AlarmSeverity.CRITICAL,
+        "Reject punch and inspect material feeding or machine coordinate setup.",
+    ),
+    AlarmCodes.DEFORMATION_LIMIT: AlarmDefinition(
+        AlarmCodes.DEFORMATION_LIMIT,
+        "local deformation exceeds process threshold",
+        AlarmSeverity.CRITICAL,
+        "Reject punch and inspect material stretch, shrinkage, wrinkle, or curl.",
+    ),
+    AlarmCodes.CONSECUTIVE_NG: AlarmDefinition(
+        AlarmCodes.CONSECUTIVE_NG,
+        "post-inspection consecutive NG count exceeds threshold",
+        AlarmSeverity.CRITICAL,
+        "Stop production and inspect tool, material, and compensation bias.",
+    ),
+    AlarmCodes.VISION_CYCLE_TIMEOUT: AlarmDefinition(
+        AlarmCodes.VISION_CYCLE_TIMEOUT,
+        "vision cycle timed out",
+        AlarmSeverity.CRITICAL,
+        "Reject punch and inspect processing load, model backend, and camera pipeline.",
+    ),
+    AlarmCodes.PLC_ACK_TIMEOUT: AlarmDefinition(
+        AlarmCodes.PLC_ACK_TIMEOUT,
+        "PLC ACK timed out",
+        AlarmSeverity.CRITICAL,
+        "Reject punch and inspect PLC handshake mapping and network latency.",
+    ),
+    AlarmCodes.CAMERA_ACQUIRE_TIMEOUT: AlarmDefinition(
+        AlarmCodes.CAMERA_ACQUIRE_TIMEOUT,
+        "camera acquisition timed out",
+        AlarmSeverity.CRITICAL,
+        "Reject punch and inspect trigger, exposure, and camera heartbeat.",
+    ),
+    AlarmCodes.LIGHT_READY_TIMEOUT: AlarmDefinition(
+        AlarmCodes.LIGHT_READY_TIMEOUT,
+        "light ready timed out",
+        AlarmSeverity.CRITICAL,
+        "Reject punch and inspect light controller trigger and ready signal.",
+    ),
+    AlarmCodes.POST_INSPECTION_TIMEOUT: AlarmDefinition(
+        AlarmCodes.POST_INSPECTION_TIMEOUT,
+        "post-inspection timed out",
+        AlarmSeverity.CRITICAL,
+        "Reject next punch and inspect post-inspection camera and algorithm runtime.",
+    ),
+    AlarmCodes.MODEL_MATCH_FAILED: AlarmDefinition(
+        AlarmCodes.MODEL_MATCH_FAILED,
+        "all matchers failed",
+        AlarmSeverity.WARNING,
+        "Keep allow_punch false and inspect model backend plus fallback matchers.",
+    ),
+    AlarmCodes.VISION_EXCEPTION: AlarmDefinition(
+        AlarmCodes.VISION_EXCEPTION,
+        "vision safety evaluation exception",
+        AlarmSeverity.CRITICAL,
+        "Keep allow_punch false and inspect logs before reset.",
+    ),
+    AlarmCodes.MANUAL_RESET_REQUIRED: AlarmDefinition(
+        AlarmCodes.MANUAL_RESET_REQUIRED,
+        "manual reset is required",
+        AlarmSeverity.INFO,
+        "Use reset_alarm only after root cause is confirmed cleared.",
+    ),
+}
+
+
+def make_alarm(alarm_code: str, message: str | None = None) -> AlarmEvent:
+    definition = ALARM_DEFINITIONS.get(
+        alarm_code,
+        AlarmDefinition(alarm_code, message or "unknown alarm", AlarmSeverity.CRITICAL, "Keep allow_punch false and inspect logs."),
+    )
+    return AlarmEvent(
+        alarm_code=definition.alarm_code,
+        alarm_message=message or definition.alarm_message,
+        severity=definition.severity,
+        recommended_action=definition.recommended_action,
+        timestamp=utc_now_iso(),
+    )

--- a/vcs_press/app/safety/safety_checker.py
+++ b/vcs_press/app/safety/safety_checker.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from app.plc.base import PLCStatus
-from app.safety.alarm_codes import AlarmCodes
+from app.safety.alarm_codes import AlarmCodes, AlarmEvent, make_alarm
 
 
 @dataclass
@@ -11,9 +11,27 @@ class SafetyDecision:
     allow_punch: bool
     alarm_code: str = AlarmCodes.OK
     alarm_message: str = ""
+    severity: str = "INFO"
+    timestamp: str = ""
+    recommended_action: str = ""
+    alarm: AlarmEvent | None = None
 
     def to_dict(self) -> dict:
-        return self.__dict__
+        alarm_dict = self.alarm.to_dict() if self.alarm else make_alarm(self.alarm_code, self.alarm_message).to_dict()
+        return {"allow_punch": self.allow_punch, **alarm_dict}
+
+    @classmethod
+    def from_alarm(cls, alarm_code: str, message: str | None = None) -> SafetyDecision:
+        alarm = make_alarm(alarm_code, message)
+        return cls(
+            allow_punch=alarm.alarm_code == AlarmCodes.OK,
+            alarm_code=alarm.alarm_code,
+            alarm_message=alarm.alarm_message,
+            severity=alarm.severity.value,
+            timestamp=alarm.timestamp,
+            recommended_action=alarm.recommended_action,
+            alarm=alarm,
+        )
 
 
 class SafetyChecker:
@@ -26,6 +44,7 @@ class SafetyChecker:
         confidence_threshold: float = 0.75,
         inlier_ratio_threshold: float = 0.40,
         residual_error_threshold_mm: float = 0.20,
+        max_local_deformation_mm: float = 1.0,
         max_consecutive_ng: int = 3,
     ):
         self.max_x_mm = max_x_mm
@@ -35,6 +54,7 @@ class SafetyChecker:
         self.confidence_threshold = confidence_threshold
         self.inlier_ratio_threshold = inlier_ratio_threshold
         self.residual_error_threshold_mm = residual_error_threshold_mm
+        self.max_local_deformation_mm = max_local_deformation_mm
         self.max_consecutive_ng = max_consecutive_ng
 
     def evaluate(
@@ -43,36 +63,62 @@ class SafetyChecker:
         registration: dict,
         compensation: dict,
         deformation: dict | None = None,
-        calibrated: bool = True,
-        cad_loaded: bool = True,
-        camera_online: bool = True,
-        light_ok: bool = True,
+        calibrated: bool | None = True,
+        cad_loaded: bool | None = True,
+        calibration_ok: bool | None = None,
+        job_loaded: bool | None = None,
+        camera_online: bool | None = True,
+        camera_connected: bool | None = None,
+        light_ok: bool | None = True,
+        light_ready: bool | None = None,
         consecutive_ng: int = 0,
+        vision_cycle_timeout: bool = False,
+        plc_ack_timeout: bool = False,
+        camera_acquire_timeout: bool = False,
+        light_ready_timeout: bool = False,
+        post_inspection_timeout: bool = False,
     ) -> SafetyDecision:
-        checks = [
-            (plc_status.safety.emergency_stop, AlarmCodes.EMERGENCY_STOP, "emergency stop is active"),
-            (plc_status.safety.safety_door_open, AlarmCodes.SAFETY_DOOR, "safety door is open"),
-            (not plc_status.safety.air_pressure_ok, AlarmCodes.AIR_PRESSURE, "air pressure is not ok"),
-            (not plc_status.connected or not plc_status.safety.plc_ok, AlarmCodes.PLC_FAULT, "PLC status is abnormal"),
-            (not camera_online, AlarmCodes.CAMERA_OFFLINE, "camera is offline"),
-            (not light_ok, AlarmCodes.LIGHT_FAULT, "light controller fault"),
-            (not calibrated, AlarmCodes.CALIBRATION_REQUIRED, "self calibration is not complete"),
-            (not cad_loaded, AlarmCodes.CAD_NOT_LOADED, "CAD/job is not loaded"),
-            (registration.get("confidence", 0.0) < self.confidence_threshold, AlarmCodes.MATCH_LOW_CONFIDENCE, "matching confidence is too low"),
-            (registration.get("inlier_ratio", 0.0) < self.inlier_ratio_threshold, AlarmCodes.MATCH_LOW_INLIER, "matching inlier ratio is too low"),
-            (registration.get("residual_error_mm", 999.0) > self.residual_error_threshold_mm, AlarmCodes.RESIDUAL_TOO_HIGH, "registration residual is too high"),
-            (consecutive_ng >= self.max_consecutive_ng, AlarmCodes.CONSECUTIVE_NG, "consecutive NG count exceeds threshold"),
-        ]
-        if deformation and not deformation.get("allow_punch", True):
-            checks.append((True, AlarmCodes.DEFORMATION_LIMIT, deformation.get("reject_reason", "deformation limit exceeded")))
-        if (
-            abs(compensation.get("x_offset_mm", 0.0)) > self.max_x_mm
-            or abs(compensation.get("y_offset_mm", 0.0)) > self.max_y_mm
-            or abs(compensation.get("feed_offset_mm", 0.0)) > self.max_feed_mm
-            or abs(compensation.get("theta_offset_deg", 0.0)) > self.max_theta_deg
-        ):
-            checks.append((True, AlarmCodes.COMPENSATION_LIMIT, "compensation exceeds machine limit"))
-        for failed, code, message in checks:
-            if failed:
-                return SafetyDecision(False, code, message)
-        return SafetyDecision(True)
+        try:
+            calibration_passed = calibrated if calibration_ok is None else calibration_ok
+            job_is_loaded = cad_loaded if job_loaded is None else job_loaded
+            camera_is_connected = camera_online if camera_connected is None else camera_connected
+            light_is_ready = light_ok if light_ready is None else light_ready
+            checks = [
+                (plc_status.safety.emergency_stop, AlarmCodes.EMERGENCY_STOP, None),
+                (plc_status.safety.safety_door_open or not plc_status.safety.safety_door_closed, AlarmCodes.SAFETY_DOOR, None),
+                (not plc_status.safety.light_curtain_ok, AlarmCodes.LIGHT_CURTAIN, None),
+                (not plc_status.safety.air_pressure_ok, AlarmCodes.AIR_PRESSURE, None),
+                (not plc_status.connected, AlarmCodes.PLC_DISCONNECTED, None),
+                (not plc_status.plc_alive, AlarmCodes.PLC_ALIVE_LOST, None),
+                (not plc_status.safety.plc_ok, AlarmCodes.PLC_FAULT, None),
+                (camera_is_connected is not True, AlarmCodes.CAMERA_OFFLINE, None),
+                (light_is_ready is not True, AlarmCodes.LIGHT_FAULT, None),
+                (calibration_passed is not True, AlarmCodes.CALIBRATION_REQUIRED, None),
+                (job_is_loaded is not True, AlarmCodes.CAD_NOT_LOADED, None),
+                (registration.get("confidence", 0.0) < self.confidence_threshold, AlarmCodes.MATCH_LOW_CONFIDENCE, None),
+                (registration.get("inlier_ratio", 0.0) < self.inlier_ratio_threshold, AlarmCodes.MATCH_LOW_INLIER, None),
+                (registration.get("residual_error_mm", 999.0) > self.residual_error_threshold_mm, AlarmCodes.RESIDUAL_TOO_HIGH, None),
+                (consecutive_ng >= self.max_consecutive_ng, AlarmCodes.CONSECUTIVE_NG, None),
+                (vision_cycle_timeout, AlarmCodes.VISION_CYCLE_TIMEOUT, None),
+                (plc_ack_timeout, AlarmCodes.PLC_ACK_TIMEOUT, None),
+                (camera_acquire_timeout, AlarmCodes.CAMERA_ACQUIRE_TIMEOUT, None),
+                (light_ready_timeout, AlarmCodes.LIGHT_READY_TIMEOUT, None),
+                (post_inspection_timeout, AlarmCodes.POST_INSPECTION_TIMEOUT, None),
+            ]
+            if deformation:
+                max_deformation = float(deformation.get("max_deformation_mm", 0.0))
+                deformation_failed = (not deformation.get("allow_punch", True)) or max_deformation > self.max_local_deformation_mm
+                checks.append((deformation_failed, AlarmCodes.DEFORMATION_LIMIT, deformation.get("reject_reason") or None))
+            if (
+                abs(float(compensation.get("x_offset_mm", 0.0))) > self.max_x_mm
+                or abs(float(compensation.get("y_offset_mm", 0.0))) > self.max_y_mm
+                or abs(float(compensation.get("feed_offset_mm", 0.0))) > self.max_feed_mm
+                or abs(float(compensation.get("theta_offset_deg", 0.0))) > self.max_theta_deg
+            ):
+                checks.append((True, AlarmCodes.COMPENSATION_LIMIT, None))
+            for failed, code, message in checks:
+                if failed:
+                    return SafetyDecision.from_alarm(code, message)
+            return SafetyDecision.from_alarm(AlarmCodes.OK)
+        except Exception as exc:
+            return SafetyDecision.from_alarm(AlarmCodes.VISION_EXCEPTION, f"safety evaluation failed: {exc}")

--- a/vcs_press/app/servo/compensation.py
+++ b/vcs_press/app/servo/compensation.py
@@ -15,6 +15,9 @@ class CompensationResult:
     reject_reason: str = ""
     alarm_code: str = "OK"
     alarm_message: str = ""
+    severity: str = "INFO"
+    recommended_action: str = ""
+    timestamp: str = ""
 
     def to_dict(self) -> dict:
         return self.__dict__

--- a/vcs_press/app/servo/servo_service.py
+++ b/vcs_press/app/servo/servo_service.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+from contextlib import suppress
 from dataclasses import asdict
 
 from app.plc.base import PLCBase
+from app.safety.alarm_codes import AlarmCodes, make_alarm
 from app.safety.safety_checker import SafetyChecker
 from app.servo.compensation import CompensationLimiter, CompensationResult
 from app.storage.report_writer import ReportWriter
@@ -16,51 +18,90 @@ class ServoService:
         self.report_writer = ReportWriter()
         self.latest_result: dict | None = None
 
-    def compute(self, registration: dict, deformation: dict | None = None, calibrated: bool = True, cad_loaded: bool = True) -> dict:
-        x, y, theta = self.limiter.clamp(
-            -float(registration.get("dx_mm", 0.0)),
-            -float(registration.get("dy_mm", 0.0)),
-            -float(registration.get("dtheta_deg", 0.0)),
-        )
-        local_offsets = deformation.get("local_offsets", []) if deformation else []
-        draft = {
-            "x_offset_mm": x,
-            "y_offset_mm": y,
-            "theta_offset_deg": theta,
-            "feed_offset_mm": 0.0,
-            "local_offsets": local_offsets,
-            "confidence": float(registration.get("confidence", 0.0)),
-        }
-        decision = self.safety_checker.evaluate(
-            self.plc.read_status(),
-            registration=registration,
-            compensation=draft,
-            deformation=deformation,
-            calibrated=calibrated,
-            cad_loaded=cad_loaded,
-        )
-        result = CompensationResult(
-            x_offset_mm=x,
-            y_offset_mm=y,
-            theta_offset_deg=theta,
-            feed_offset_mm=0.0,
-            local_offsets=local_offsets,
-            confidence=draft["confidence"],
-            allow_punch=decision.allow_punch,
-            reject_reason=decision.alarm_message,
-            alarm_code=decision.alarm_code,
-            alarm_message=decision.alarm_message,
-        ).to_dict()
+    def compute(
+        self,
+        registration: dict,
+        deformation: dict | None = None,
+        calibrated: bool = True,
+        cad_loaded: bool = True,
+        **safety_flags,
+    ) -> dict:
+        try:
+            raw_x = -float(registration.get("dx_mm", 0.0))
+            raw_y = -float(registration.get("dy_mm", 0.0))
+            raw_theta = -float(registration.get("dtheta_deg", 0.0))
+            x, y, theta = self.limiter.clamp(raw_x, raw_y, raw_theta)
+            local_offsets = deformation.get("local_offsets", []) if deformation else []
+            safety_payload = {
+                "x_offset_mm": raw_x,
+                "y_offset_mm": raw_y,
+                "theta_offset_deg": raw_theta,
+                "feed_offset_mm": 0.0,
+                "local_offsets": local_offsets,
+                "confidence": float(registration.get("confidence", 0.0)),
+            }
+            decision = self.safety_checker.evaluate(
+                self.plc.read_status(),
+                registration=registration,
+                compensation=safety_payload,
+                deformation=deformation,
+                calibrated=calibrated,
+                cad_loaded=cad_loaded,
+                **safety_flags,
+            )
+            result = CompensationResult(
+                x_offset_mm=x,
+                y_offset_mm=y,
+                theta_offset_deg=theta,
+                feed_offset_mm=0.0,
+                local_offsets=local_offsets,
+                confidence=safety_payload["confidence"],
+                allow_punch=decision.allow_punch,
+                reject_reason=decision.alarm_message,
+                alarm_code=decision.alarm_code,
+                alarm_message=decision.alarm_message,
+                severity=decision.severity,
+                recommended_action=decision.recommended_action,
+                timestamp=decision.timestamp,
+            ).to_dict()
+        except Exception as exc:
+            result = self._fail_closed(f"servo compute failed: {exc}")
         self.latest_result = result
         self.report_writer.write_json("servo_compensation_latest.json", result)
         return result
 
     def send_to_plc(self, result: dict | None = None) -> dict:
-        payload = result or self.latest_result
-        if payload is None:
-            raise RuntimeError("no compensation result available")
-        self.plc.write_compensation(payload)
-        self.plc.write_allow_punch(bool(payload.get("allow_punch", False)))
-        if not payload.get("allow_punch", False):
-            self.plc.write_alarm(payload.get("alarm_code", "VISION_REJECT"), payload.get("alarm_message", "vision rejected punch"))
-        return {"sent": True, "allow_punch": bool(payload.get("allow_punch", False)), "plc_status": asdict(self.plc.read_status())}
+        payload = result or self.latest_result or self._fail_closed("no compensation result available")
+        try:
+            self.plc.write_allow_punch(False)
+            self.plc.write_compensation(payload)
+            allow = bool(payload.get("allow_punch", False))
+            self.plc.write_allow_punch(allow)
+            if not allow:
+                self.plc.write_alarm(payload.get("alarm_code", "VISION_REJECT"), payload.get("alarm_message", "vision rejected punch"))
+            return {"sent": True, "allow_punch": allow, "plc_status": asdict(self.plc.read_status())}
+        except Exception as exc:
+            fail = self._fail_closed(f"PLC write failed: {exc}")
+            self.latest_result = fail
+            with suppress(Exception):
+                self.plc.write_allow_punch(False)
+            return {"sent": False, "allow_punch": False, "error": str(exc), "plc_status": asdict(self.plc.read_status())}
+
+    def _fail_closed(self, message: str) -> dict:
+        alarm = make_alarm(AlarmCodes.VISION_EXCEPTION, message)
+        result = CompensationResult(
+            x_offset_mm=0.0,
+            y_offset_mm=0.0,
+            theta_offset_deg=0.0,
+            feed_offset_mm=0.0,
+            confidence=0.0,
+            allow_punch=False,
+            reject_reason=message,
+            alarm_code=alarm.alarm_code,
+            alarm_message=alarm.alarm_message,
+            severity=alarm.severity.value,
+            recommended_action=alarm.recommended_action,
+            timestamp=alarm.timestamp,
+        ).to_dict()
+        self.latest_result = result
+        return result

--- a/vcs_press/app/state_machine/__init__.py
+++ b/vcs_press/app/state_machine/__init__.py
@@ -1,4 +1,4 @@
 from app.state_machine.controller import StateMachineController
-from app.state_machine.states import MachineState, STATE_CODES
+from app.state_machine.states import STATE_CODES, MachineState
 
 __all__ = ["StateMachineController", "MachineState", "STATE_CODES"]

--- a/vcs_press/app/state_machine/controller.py
+++ b/vcs_press/app/state_machine/controller.py
@@ -4,9 +4,10 @@ from dataclasses import dataclass, field
 
 from loguru import logger
 
-from app.state_machine.states import MachineState, STATE_CODES
+from app.safety.alarm_codes import AlarmCodes, AlarmEvent, AlarmSeverity, make_alarm
+from app.safety.safety_checker import SafetyDecision
+from app.state_machine.states import STATE_CODES, MachineState
 from app.utils.time_utils import utc_now_iso
-
 
 ALLOWED_TRANSITIONS = {
     MachineState.IDLE: {MachineState.INIT, MachineState.ALARM, MachineState.EMERGENCY_STOP},
@@ -35,19 +36,60 @@ class StateMachineController:
     state: MachineState = MachineState.IDLE
     history: list[dict] = field(default_factory=list)
     alarm: dict = field(default_factory=dict)
+    _alarm_reset_authorized: bool = False
+    _emergency_acknowledged: bool = False
 
     def transition(self, next_state: MachineState, reason: str = "") -> None:
+        if (
+            self.state == MachineState.ALARM
+            and next_state not in {MachineState.ALARM, MachineState.EMERGENCY_STOP}
+            and not self._alarm_reset_authorized
+        ):
+            raise ValueError("ALARM recovery requires explicit reset_alarm")
+        if self.state == MachineState.EMERGENCY_STOP and next_state != MachineState.EMERGENCY_STOP and not self._emergency_acknowledged:
+            raise ValueError("EMERGENCY_STOP recovery requires PLC and operator acknowledgement")
         if next_state not in ALLOWED_TRANSITIONS[self.state]:
             raise ValueError(f"invalid transition {self.state} -> {next_state}")
         entry = {"from": self.state.value, "to": next_state.value, "reason": reason, "timestamp": utc_now_iso()}
         logger.info("state transition {} -> {} {}", self.state.value, next_state.value, reason)
         self.history.append(entry)
         self.state = next_state
+        self._alarm_reset_authorized = False
+        self._emergency_acknowledged = False
 
     def set_alarm(self, code: str, message: str) -> None:
-        self.alarm = {"code": code, "message": message, "timestamp": utc_now_iso()}
+        self.enter_alarm(make_alarm(code, message))
+
+    def enter_alarm(self, alarm: AlarmEvent) -> None:
+        self.alarm = alarm.to_dict()
+        target = MachineState.EMERGENCY_STOP if alarm.severity == AlarmSeverity.EMERGENCY else MachineState.ALARM
+        if self.state == MachineState.EMERGENCY_STOP and target != MachineState.EMERGENCY_STOP:
+            return
+        if self.state != target:
+            self.transition(target, alarm.alarm_message)
+
+    def apply_safety_decision(self, decision: SafetyDecision) -> None:
+        if decision.allow_punch:
+            return
+        alarm = decision.alarm or make_alarm(decision.alarm_code, decision.alarm_message)
+        if alarm.severity in {AlarmSeverity.CRITICAL, AlarmSeverity.EMERGENCY}:
+            self.enter_alarm(alarm)
+
+    def reset_alarm(self) -> None:
         if self.state != MachineState.ALARM:
-            self.transition(MachineState.ALARM, message)
+            raise ValueError("reset_alarm is only valid from ALARM")
+        self._alarm_reset_authorized = True
+        self.alarm = make_alarm(AlarmCodes.MANUAL_RESET_REQUIRED, "alarm reset by explicit operator action").to_dict()
+        self.transition(MachineState.IDLE, "alarm reset")
+
+    def acknowledge_emergency_stop(self, plc_confirmed: bool, operator_confirmed: bool) -> None:
+        if self.state != MachineState.EMERGENCY_STOP:
+            raise ValueError("emergency acknowledgement is only valid from EMERGENCY_STOP")
+        if not (plc_confirmed and operator_confirmed):
+            raise ValueError("PLC and operator acknowledgement are both required")
+        self._emergency_acknowledged = True
+        self.alarm = make_alarm(AlarmCodes.MANUAL_RESET_REQUIRED, "emergency stop acknowledged by PLC and operator").to_dict()
+        self.transition(MachineState.IDLE, "emergency stop acknowledged")
 
     def status(self) -> dict:
         return {

--- a/vcs_press/app/storage/__init__.py
+++ b/vcs_press/app/storage/__init__.py
@@ -1,4 +1,4 @@
-from app.storage.repository import InMemoryRepository, ProductionRecord
 from app.storage.report_writer import ReportWriter
+from app.storage.repository import InMemoryRepository, ProductionRecord
 
 __all__ = ["InMemoryRepository", "ProductionRecord", "ReportWriter"]

--- a/vcs_press/app/utils/geometry.py
+++ b/vcs_press/app/utils/geometry.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import math
-from typing import Iterable
+from collections.abc import Iterable
 
 import cv2
 import numpy as np

--- a/vcs_press/app/utils/image_io.py
+++ b/vcs_press/app/utils/image_io.py
@@ -17,7 +17,7 @@ def write_image(path: str | Path, image: np.ndarray) -> str:
     out = Path(path)
     out.parent.mkdir(parents=True, exist_ok=True)
     if not cv2.imwrite(str(out), image):
-        raise IOError(f"unable to write image: {out}")
+        raise OSError(f"unable to write image: {out}")
     return str(out)
 
 

--- a/vcs_press/app/vision_matching/lightglue_stub.py
+++ b/vcs_press/app/vision_matching/lightglue_stub.py
@@ -51,8 +51,8 @@ class SuperPointLightGlueMatcher(FeatureMatcher):
             torch = importlib.import_module("torch")
             lightglue = importlib.import_module("lightglue")
             utils = importlib.import_module("lightglue.utils")
-            SuperPoint = getattr(lightglue, "SuperPoint")
-            LightGlue = getattr(lightglue, "LightGlue")
+            SuperPoint = lightglue.SuperPoint
+            LightGlue = lightglue.LightGlue
             self._rbd = getattr(utils, "rbd", _remove_batch_dimension)
             requested_device = self.config.device
             self.device = ("cuda" if torch.cuda.is_available() else "cpu") if requested_device in (None, "auto") else requested_device
@@ -75,7 +75,9 @@ class SuperPointLightGlueMatcher(FeatureMatcher):
         feats0, feats1, matches01 = [self._rbd(x) for x in (feats0, feats1, matches01)]
         matches = matches01.get("matches")
         if matches is None or int(matches.shape[0]) < 4:
-            return MatchResult([], [], 0.0, 0.0, None, None, 999.0, metadata={"matcher": self.name, "reason": "insufficient_lightglue_matches"})
+            return MatchResult(
+                [], [], 0.0, 0.0, None, None, 999.0, metadata={"matcher": self.name, "reason": "insufficient_lightglue_matches"}
+            )
         keypoints0 = feats0["keypoints"][matches[:, 0]].detach().cpu().numpy().astype(np.float32)
         keypoints1 = feats1["keypoints"][matches[:, 1]].detach().cpu().numpy().astype(np.float32)
         scores = matches01.get("scores")
@@ -103,13 +105,12 @@ class SuperPointLightGlueMatcher(FeatureMatcher):
     def _image_to_tensor(self, image: np.ndarray):
         rgb = cv2.cvtColor(image, cv2.COLOR_BGR2RGB) if image.ndim == 3 else image
         tensor = self._torch.from_numpy(rgb).float() / 255.0
-        if tensor.ndim == 2:
-            tensor = tensor.unsqueeze(0)
-        else:
-            tensor = tensor.permute(2, 0, 1)
+        tensor = tensor.unsqueeze(0) if tensor.ndim == 2 else tensor.permute(2, 0, 1)
         return tensor.to(self.device)
 
-    def _fallback(self, template_image: np.ndarray, current_image: np.ndarray, roi: tuple[int, int, int, int] | None, reason: str) -> MatchResult:
+    def _fallback(
+        self, template_image: np.ndarray, current_image: np.ndarray, roi: tuple[int, int, int, int] | None, reason: str
+    ) -> MatchResult:
         if not self.config.use_fallback:
             return MatchResult([], [], 0.0, 0.0, None, None, 999.0, metadata={"matcher": self.name, "reason": reason})
         result = self.fallback.match(template_image, current_image, roi)
@@ -147,10 +148,12 @@ def _mean_residual(src: np.ndarray, dst: np.ndarray, affine: np.ndarray, inliers
     return float(np.mean(np.linalg.norm(projected - dst[inliers], axis=1)))
 
 
-def _draw_matches(template_image: np.ndarray, current_image: np.ndarray, src: np.ndarray, dst: np.ndarray, inliers: np.ndarray) -> np.ndarray:
+def _draw_matches(
+    template_image: np.ndarray, current_image: np.ndarray, src: np.ndarray, dst: np.ndarray, inliers: np.ndarray
+) -> np.ndarray:
     canvas = np.hstack([template_image, current_image])
     width = template_image.shape[1]
-    for p, q, ok in zip(src.astype(int), dst.astype(int), inliers):
+    for p, q, ok in zip(src.astype(int), dst.astype(int), inliers, strict=False):
         color = (0, 220, 0) if ok else (0, 0, 220)
         q2 = (int(q[0] + width), int(q[1]))
         cv2.circle(canvas, tuple(p), 3, color, -1)

--- a/vcs_press/app/vision_matching/mock_deep_matcher.py
+++ b/vcs_press/app/vision_matching/mock_deep_matcher.py
@@ -20,7 +20,7 @@ class MockDeepMatcher(FeatureMatcher):
         hom = np.vstack([transform, [0.0, 0.0, 1.0]])
         residual = float(np.mean(np.linalg.norm(apply_transform(src, transform) - dst, axis=1)))
         vis = np.hstack([template_image, current_image])
-        for p, q in zip(src.astype(int), dst.astype(int)):
+        for p, q in zip(src.astype(int), dst.astype(int), strict=False):
             q2 = (int(q[0] + template_image.shape[1]), int(q[1]))
             cv2.circle(vis, tuple(p), 3, (0, 255, 0), -1)
             cv2.circle(vis, q2, 3, (0, 0, 255), -1)

--- a/vcs_press/app/vision_matching/orb_matcher.py
+++ b/vcs_press/app/vision_matching/orb_matcher.py
@@ -33,7 +33,9 @@ class ORBMatcher(FeatureMatcher):
         inliers = mask.reshape(-1).astype(bool) if mask is not None else np.ones(len(src), dtype=bool)
         if affine is None:
             affine = np.eye(2, 3, dtype=np.float64)
-        residual = float(np.mean(np.linalg.norm(apply_transform(src[inliers], affine) - dst[inliers], axis=1))) if np.any(inliers) else 999.0
+        residual = (
+            float(np.mean(np.linalg.norm(apply_transform(src[inliers], affine) - dst[inliers], axis=1))) if np.any(inliers) else 999.0
+        )
         confidence = float(max(0.0, min(1.0, np.mean(inliers) * (1.0 / (1.0 + residual / 10.0)))))
         vis = cv2.drawMatches(template_image, kp1, current_image, kp2, [matches[i] for i in np.where(inliers)[0][:50]], None)
         return MatchResult(

--- a/vcs_press/app/vision_matching/sift_matcher.py
+++ b/vcs_press/app/vision_matching/sift_matcher.py
@@ -34,7 +34,11 @@ class SIFTMatcher(FeatureMatcher):
         homography, mask = cv2.findHomography(src, dst, cv2.RANSAC, 3.0)
         affine, _ = cv2.estimateAffinePartial2D(src, dst, method=cv2.RANSAC, ransacReprojThreshold=3.0)
         inliers = mask.reshape(-1).astype(bool) if mask is not None else np.ones(len(src), dtype=bool)
-        residual = float(np.mean(np.linalg.norm(apply_transform(src[inliers], affine) - dst[inliers], axis=1))) if affine is not None and np.any(inliers) else 999.0
+        residual = (
+            float(np.mean(np.linalg.norm(apply_transform(src[inliers], affine) - dst[inliers], axis=1)))
+            if affine is not None and np.any(inliers)
+            else 999.0
+        )
         return MatchResult(
             [tuple(map(float, p)) for p in src],
             [tuple(map(float, p)) for p in dst],

--- a/vcs_press/config/safety.yaml
+++ b/vcs_press/config/safety.yaml
@@ -4,3 +4,9 @@ safety:
   require_cad_loaded: true
   reject_on_light_fault: true
   reject_on_camera_offline: true
+  timeouts:
+    camera_acquire_timeout_ms: 1000
+    vision_process_timeout_ms: 500
+    plc_ack_timeout_ms: 300
+    light_ready_timeout_ms: 200
+    post_inspection_timeout_ms: 1000

--- a/vcs_press/main.py
+++ b/vcs_press/main.py
@@ -1,6 +1,5 @@
 from app.api.routes import create_app
 
-
 app = create_app()
 
 

--- a/vcs_press/pyproject.toml
+++ b/vcs_press/pyproject.toml
@@ -1,0 +1,25 @@
+[tool.black]
+line-length = 140
+target-version = ["py310"]
+
+[tool.isort]
+profile = "black"
+line_length = 140
+known_first_party = ["app"]
+
+[tool.ruff]
+line-length = 140
+target-version = "py310"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B", "SIM"]
+ignore = ["B008"]
+
+[tool.mypy]
+python_version = "3.10"
+ignore_missing_imports = true
+warn_unused_ignores = true
+warn_redundant_casts = true
+no_implicit_optional = false
+check_untyped_defs = false
+exclude = ["data/"]

--- a/vcs_press/requirements.txt
+++ b/vcs_press/requirements.txt
@@ -15,3 +15,8 @@ PyYAML
 loguru
 pytest
 httpx
+ruff
+black
+isort
+mypy
+pre-commit

--- a/vcs_press/scripts/check_unicode_safety.py
+++ b/vcs_press/scripts/check_unicode_safety.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+DANGEROUS_CODEPOINTS = {
+    "\u200b": "ZERO WIDTH SPACE",
+    "\u200c": "ZERO WIDTH NON-JOINER",
+    "\u200d": "ZERO WIDTH JOINER",
+    "\u200e": "LEFT-TO-RIGHT MARK",
+    "\u200f": "RIGHT-TO-LEFT MARK",
+    "\u202a": "LEFT-TO-RIGHT EMBEDDING",
+    "\u202b": "RIGHT-TO-LEFT EMBEDDING",
+    "\u202c": "POP DIRECTIONAL FORMATTING",
+    "\u202d": "LEFT-TO-RIGHT OVERRIDE",
+    "\u202e": "RIGHT-TO-LEFT OVERRIDE",
+    "\u2060": "WORD JOINER",
+    "\u2066": "LEFT-TO-RIGHT ISOLATE",
+    "\u2067": "RIGHT-TO-LEFT ISOLATE",
+    "\u2068": "FIRST STRONG ISOLATE",
+    "\u2069": "POP DIRECTIONAL ISOLATE",
+    "\ufeff": "BYTE ORDER MARK",
+}
+
+TEXT_EXTENSIONS = {".py", ".yaml", ".yml", ".md", ".txt"}
+SKIP_DIRS = {".git", ".mypy_cache", ".pytest_cache", ".ruff_cache", "__pycache__"}
+
+
+def iter_text_files(root: Path) -> list[Path]:
+    files: list[Path] = []
+    for path in root.rglob("*"):
+        if any(part in SKIP_DIRS for part in path.parts):
+            continue
+        if path.is_file() and path.suffix.lower() in TEXT_EXTENSIONS:
+            files.append(path)
+    return sorted(files)
+
+
+def scan_file(path: Path) -> list[str]:
+    findings: list[str] = []
+    text = path.read_text(encoding="utf-8")
+    for line_no, line in enumerate(text.splitlines(), start=1):
+        for column, char in enumerate(line, start=1):
+            if char in DANGEROUS_CODEPOINTS:
+                codepoint = f"U+{ord(char):04X}"
+                findings.append(f"{path}:{line_no}:{column}: {codepoint} {DANGEROUS_CODEPOINTS[char]}")
+    return findings
+
+
+def main() -> int:
+    root = Path(__file__).resolve().parents[1]
+    findings: list[str] = []
+    for path in iter_text_files(root):
+        findings.extend(scan_file(path))
+    if findings:
+        print("Dangerous hidden Unicode characters detected:")
+        for finding in findings:
+            print(finding)
+        return 1
+    print("Unicode safety check passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/vcs_press/tests/test_alarm_codes.py
+++ b/vcs_press/tests/test_alarm_codes.py
@@ -1,0 +1,20 @@
+from app.safety.alarm_codes import ALARM_DEFINITIONS, AlarmCodes, AlarmSeverity, make_alarm
+
+
+def test_all_alarm_definitions_have_required_fields():
+    severities = {severity.value for severity in AlarmSeverity}
+    assert {"INFO", "WARNING", "CRITICAL", "EMERGENCY"} <= severities
+    for code, definition in ALARM_DEFINITIONS.items():
+        event = make_alarm(code)
+        payload = event.to_dict()
+        assert payload["alarm_code"] == definition.alarm_code
+        assert payload["alarm_message"]
+        assert payload["severity"] in severities
+        assert payload["timestamp"]
+        assert payload["recommended_action"]
+
+
+def test_emergency_stop_alarm_is_emergency():
+    alarm = make_alarm(AlarmCodes.EMERGENCY_STOP)
+    assert alarm.severity == AlarmSeverity.EMERGENCY
+    assert "emergency stop" in alarm.alarm_message

--- a/vcs_press/tests/test_hole_detector.py
+++ b/vcs_press/tests/test_hole_detector.py
@@ -7,6 +7,6 @@ def test_hole_detector_finds_reference_centers():
     image = synthetic_hole_image(points)
     result = HoleDetector().detect(image, expected_count=4)
     assert len(result.centers) == 4
-    for detected, expected in zip(result.centers, points):
+    for detected, expected in zip(result.centers, points, strict=False):
         assert abs(detected[0] - expected[0]) < 1.0
         assert abs(detected[1] - expected[1]) < 1.0

--- a/vcs_press/tests/test_industrial_safety.py
+++ b/vcs_press/tests/test_industrial_safety.py
@@ -1,0 +1,81 @@
+import pytest
+
+from app.plc.base import PLCStatus, SafetySignals
+from app.safety.alarm_codes import AlarmCodes
+from app.safety.safety_checker import SafetyChecker
+
+GOOD_REGISTRATION = {"confidence": 0.9, "inlier_ratio": 0.9, "residual_error_mm": 0.01}
+GOOD_COMPENSATION = {"x_offset_mm": 0.1, "y_offset_mm": 0.1, "theta_offset_deg": 0.0, "feed_offset_mm": 0.0}
+GOOD_DEFORMATION = {"allow_punch": True, "max_deformation_mm": 0.1, "local_offsets": []}
+
+
+def evaluate(status: PLCStatus | None = None, **kwargs):
+    return SafetyChecker().evaluate(
+        status or PLCStatus(),
+        registration=kwargs.pop("registration", GOOD_REGISTRATION),
+        compensation=kwargs.pop("compensation", GOOD_COMPENSATION),
+        deformation=kwargs.pop("deformation", GOOD_DEFORMATION),
+        **kwargs,
+    )
+
+
+@pytest.mark.parametrize(
+    ("status", "expected_code"),
+    [
+        (PLCStatus(safety=SafetySignals(emergency_stop=True)), AlarmCodes.EMERGENCY_STOP),
+        (PLCStatus(safety=SafetySignals(safety_door_closed=False)), AlarmCodes.SAFETY_DOOR),
+        (PLCStatus(safety=SafetySignals(safety_door_open=True)), AlarmCodes.SAFETY_DOOR),
+        (PLCStatus(safety=SafetySignals(light_curtain_ok=False)), AlarmCodes.LIGHT_CURTAIN),
+        (PLCStatus(safety=SafetySignals(air_pressure_ok=False)), AlarmCodes.AIR_PRESSURE),
+        (PLCStatus(connected=False), AlarmCodes.PLC_DISCONNECTED),
+        (PLCStatus(plc_alive=False), AlarmCodes.PLC_ALIVE_LOST),
+        (PLCStatus(safety=SafetySignals(plc_ok=False)), AlarmCodes.PLC_FAULT),
+    ],
+)
+def test_plc_and_safety_signal_faults_block_punch(status, expected_code):
+    decision = evaluate(status)
+    assert decision.allow_punch is False
+    assert decision.alarm_code == expected_code
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "expected_code"),
+    [
+        ({"camera_connected": False}, AlarmCodes.CAMERA_OFFLINE),
+        ({"light_ready": False}, AlarmCodes.LIGHT_FAULT),
+        ({"calibration_ok": False}, AlarmCodes.CALIBRATION_REQUIRED),
+        ({"job_loaded": False}, AlarmCodes.CAD_NOT_LOADED),
+        ({"registration": {"confidence": 0.1, "inlier_ratio": 0.9, "residual_error_mm": 0.01}}, AlarmCodes.MATCH_LOW_CONFIDENCE),
+        ({"registration": {"confidence": 0.9, "inlier_ratio": 0.1, "residual_error_mm": 0.01}}, AlarmCodes.MATCH_LOW_INLIER),
+        ({"registration": {"confidence": 0.9, "inlier_ratio": 0.9, "residual_error_mm": 0.5}}, AlarmCodes.RESIDUAL_TOO_HIGH),
+        (
+            {"compensation": {"x_offset_mm": 6.0, "y_offset_mm": 0.0, "theta_offset_deg": 0.0, "feed_offset_mm": 0.0}},
+            AlarmCodes.COMPENSATION_LIMIT,
+        ),
+        (
+            {"compensation": {"x_offset_mm": 0.0, "y_offset_mm": 6.0, "theta_offset_deg": 0.0, "feed_offset_mm": 0.0}},
+            AlarmCodes.COMPENSATION_LIMIT,
+        ),
+        (
+            {"compensation": {"x_offset_mm": 0.0, "y_offset_mm": 0.0, "theta_offset_deg": 0.0, "feed_offset_mm": 11.0}},
+            AlarmCodes.COMPENSATION_LIMIT,
+        ),
+        (
+            {"compensation": {"x_offset_mm": 0.0, "y_offset_mm": 0.0, "theta_offset_deg": 3.0, "feed_offset_mm": 0.0}},
+            AlarmCodes.COMPENSATION_LIMIT,
+        ),
+        ({"deformation": {"allow_punch": True, "max_deformation_mm": 2.0}}, AlarmCodes.DEFORMATION_LIMIT),
+        ({"deformation": {"allow_punch": False, "reject_reason": "material curl exceeds limit"}}, AlarmCodes.DEFORMATION_LIMIT),
+        ({"consecutive_ng": 3}, AlarmCodes.CONSECUTIVE_NG),
+    ],
+)
+def test_vision_and_process_faults_block_punch(kwargs, expected_code):
+    decision = evaluate(**kwargs)
+    assert decision.allow_punch is False
+    assert decision.alarm_code == expected_code
+
+
+def test_nominal_industrial_safety_allows_punch_recommendation():
+    decision = evaluate(calibration_ok=True, job_loaded=True, camera_connected=True, light_ready=True)
+    assert decision.allow_punch is True
+    assert decision.alarm_code == AlarmCodes.OK

--- a/vcs_press/tests/test_lightglue_matcher.py
+++ b/vcs_press/tests/test_lightglue_matcher.py
@@ -54,7 +54,9 @@ def test_lightglue_backend_path_with_fake_package(monkeypatch):
             return {key: rbd(value) for key, value in data.items()}
         return data[0] if hasattr(data, "shape") and data.shape[0] == 1 else data
 
-    monkeypatch.setitem(importlib.import_module("sys").modules, "lightglue", types.SimpleNamespace(SuperPoint=FakeSuperPoint, LightGlue=FakeLightGlue))
+    monkeypatch.setitem(
+        importlib.import_module("sys").modules, "lightglue", types.SimpleNamespace(SuperPoint=FakeSuperPoint, LightGlue=FakeLightGlue)
+    )
     monkeypatch.setitem(importlib.import_module("sys").modules, "lightglue.utils", types.SimpleNamespace(rbd=rbd))
 
     matcher = SuperPointLightGlueMatcher(config=LightGlueConfig(device="cpu", use_fallback=False))

--- a/vcs_press/tests/test_state_machine.py
+++ b/vcs_press/tests/test_state_machine.py
@@ -1,3 +1,5 @@
+import pytest
+
 from app.state_machine.controller import StateMachineController
 from app.state_machine.states import MachineState
 
@@ -26,9 +28,5 @@ def test_state_machine_nominal_flow():
 
 def test_state_machine_rejects_invalid_transition():
     sm = StateMachineController()
-    try:
+    with pytest.raises(ValueError):
         sm.transition(MachineState.PUNCH_ALLOWED, "invalid")
-    except ValueError:
-        assert True
-    else:
-        assert False, "invalid transition should raise"

--- a/vcs_press/tests/test_state_machine_safety.py
+++ b/vcs_press/tests/test_state_machine_safety.py
@@ -1,0 +1,34 @@
+import pytest
+
+from app.safety.alarm_codes import AlarmCodes, AlarmSeverity, make_alarm
+from app.safety.safety_checker import SafetyDecision
+from app.state_machine.controller import StateMachineController
+from app.state_machine.states import MachineState
+
+
+def test_critical_safety_decision_enters_alarm_and_requires_reset():
+    sm = StateMachineController()
+    decision = SafetyDecision.from_alarm(AlarmCodes.PLC_DISCONNECTED)
+    sm.apply_safety_decision(decision)
+
+    assert sm.state == MachineState.ALARM
+    assert sm.alarm["severity"] == AlarmSeverity.CRITICAL.value
+    with pytest.raises(ValueError):
+        sm.transition(MachineState.IDLE, "unsafe auto recovery")
+
+    sm.reset_alarm()
+    assert sm.state == MachineState.IDLE
+
+
+def test_emergency_stop_requires_plc_and_operator_acknowledgement():
+    sm = StateMachineController()
+    sm.enter_alarm(make_alarm(AlarmCodes.EMERGENCY_STOP))
+
+    assert sm.state == MachineState.EMERGENCY_STOP
+    with pytest.raises(ValueError):
+        sm.transition(MachineState.IDLE, "unsafe emergency recovery")
+    with pytest.raises(ValueError):
+        sm.acknowledge_emergency_stop(plc_confirmed=True, operator_confirmed=False)
+
+    sm.acknowledge_emergency_stop(plc_confirmed=True, operator_confirmed=True)
+    assert sm.state == MachineState.IDLE

--- a/vcs_press/tests/test_timeout_safety.py
+++ b/vcs_press/tests/test_timeout_safety.py
@@ -1,0 +1,52 @@
+import pytest
+
+from app.plc.simulated_plc import SimulatedPLC
+from app.safety.alarm_codes import AlarmCodes
+from app.safety.safety_checker import SafetyChecker
+from app.servo.servo_service import ServoService
+
+GOOD_REGISTRATION = {"dx_mm": 0.1, "dy_mm": 0.1, "dtheta_deg": 0.0, "confidence": 0.9, "inlier_ratio": 0.9, "residual_error_mm": 0.01}
+GOOD_COMPENSATION = {"x_offset_mm": 0.0, "y_offset_mm": 0.0, "theta_offset_deg": 0.0, "feed_offset_mm": 0.0}
+
+
+@pytest.mark.parametrize(
+    ("timeout_flag", "expected_code"),
+    [
+        ("camera_acquire_timeout", AlarmCodes.CAMERA_ACQUIRE_TIMEOUT),
+        ("vision_cycle_timeout", AlarmCodes.VISION_CYCLE_TIMEOUT),
+        ("plc_ack_timeout", AlarmCodes.PLC_ACK_TIMEOUT),
+        ("light_ready_timeout", AlarmCodes.LIGHT_READY_TIMEOUT),
+        ("post_inspection_timeout", AlarmCodes.POST_INSPECTION_TIMEOUT),
+    ],
+)
+def test_timeout_flags_block_punch(timeout_flag, expected_code):
+    decision = SafetyChecker().evaluate(
+        SimulatedPLC().read_status(),
+        registration=GOOD_REGISTRATION,
+        compensation=GOOD_COMPENSATION,
+        deformation={"allow_punch": True, "max_deformation_mm": 0.0},
+        **{timeout_flag: True},
+    )
+    assert decision.allow_punch is False
+    assert decision.alarm_code == expected_code
+
+
+def test_servo_compute_timeout_fails_closed_and_plc_write_clears_allow():
+    plc = SimulatedPLC()
+    servo = ServoService(plc)
+    ok = servo.compute(GOOD_REGISTRATION, {"allow_punch": True, "max_deformation_mm": 0.0}, calibrated=True, cad_loaded=True)
+    assert ok["allow_punch"] is True
+    servo.send_to_plc(ok)
+    assert plc.allow_punch is True
+
+    rejected = servo.compute(
+        GOOD_REGISTRATION,
+        {"allow_punch": True, "max_deformation_mm": 0.0},
+        calibrated=True,
+        cad_loaded=True,
+        plc_ack_timeout=True,
+    )
+    assert rejected["allow_punch"] is False
+    assert rejected["alarm_code"] == AlarmCodes.PLC_ACK_TIMEOUT
+    servo.send_to_plc(rejected)
+    assert plc.allow_punch is False

--- a/vcs_press/tests/test_unicode_safety.py
+++ b/vcs_press/tests/test_unicode_safety.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+from scripts.check_unicode_safety import scan_file
+
+
+def test_unicode_safety_allows_plain_ascii(tmp_path: Path):
+    path = tmp_path / "plain.py"
+    path.write_text("print('safe')\n", encoding="utf-8")
+    assert scan_file(path) == []
+
+
+def test_unicode_safety_rejects_bidi_control(tmp_path: Path):
+    path = tmp_path / "unsafe.py"
+    path.write_text("name = 'abc" + chr(0x202E) + "'\n", encoding="utf-8")
+    findings = scan_file(path)
+    assert findings
+    assert "U+202E" in findings[0]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Adds Unicode safety scanning, `pyproject.toml`, ruff/black/isort/mypy configuration, pre-commit hooks, and GitHub Actions CI.
- Standardizes alarm definitions into structured events with code, message, severity, timestamp, and recommended action.
- Hardens safety checks for PLC/safety signals, camera/light readiness, calibration/job state, matcher quality, compensation limits, deformation limits, consecutive NG, and all requested timeout flags.
- Makes servo PLC writes fail closed by clearing `allow_punch` before each payload and on any exception.
- Strengthens state-machine recovery so `ALARM` requires explicit reset and `EMERGENCY_STOP` requires PLC plus operator acknowledgement.
- Updates README with industrial safety boundaries, CI/pre-commit usage, alarm model, Unicode safety rationale, and simulated safety tests.

### Validation
- `python3 scripts/check_unicode_safety.py` passed.
- `python3 -m ruff check .` passed.
- `python3 -m black --check .` passed.
- `python3 -m isort --check-only .` passed.
- `python3 -m pytest -q` passed: 49 tests.
- Restarted `python3 main.py` and exercised the simulated HTTP calibration/register/servo/PLC/status flow successfully.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3484facf-1294-48f7-96e1-13ee6eb29e83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3484facf-1294-48f7-96e1-13ee6eb29e83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

